### PR TITLE
Fix command not found by adding bin_path to PATH for subprocess commands

### DIFF
--- a/applications_download/__init__.py
+++ b/applications_download/__init__.py
@@ -259,11 +259,12 @@ class Applications:
                 with (bin_path / additional_filename).open("w", encoding="utf-8") as additional_file:
                     additional_file.write(additional_content)
 
+            env = {**os.environ, "PATH": f"{bin_path}:{os.environ.get('PATH', '')}"}
             for command in app.get("finish-commands", []):
-                subprocess.run(command, check=True, cwd=bin_path)  # noqa: S603
+                subprocess.run(command, check=True, cwd=bin_path, env=env)  # noqa: S603
 
             if "version-command" in app:
-                subprocess.run(app["version-command"], check=True, cwd=bin_path)  # noqa: S603
+                subprocess.run(app["version-command"], check=True, cwd=bin_path, env=env)  # noqa: S603
 
             if app.get("remove-after-success", False):
                 (bin_path / app["to-file-name"]).unlink()

--- a/applications_download/applications.yaml
+++ b/applications_download/applications.yaml
@@ -181,6 +181,7 @@ cli/cli:
       - apt-get
       - install
       - --yes
+      - --allow-downgrades
       - ./gh.deb
   version-command:
     - gh


### PR DESCRIPTION
subprocess.run() searches PATH, not cwd, to find executables. When `finish-commands` or `version-command` reference the downloaded binary, it isn't found because `~/.local/bin` is not in PATH.

Fix by passing an environment with `bin_path` prepended to PATH.

Fixes errors like:
- `google-java-format` not found
- `docker-compose` not found
- `rtk` not found